### PR TITLE
Disable players open the Twilight Uncrafting_table

### DIFF
--- a/kubejs/server_scripts/mod_specific/twilightforest/twilight.js
+++ b/kubejs/server_scripts/mod_specific/twilightforest/twilight.js
@@ -1,3 +1,9 @@
 onEvent('recipes', event => {
     event.remove({ id: 'twilightforest:uncrafting_table' })
 })
+
+onEvent('block.right_click', event => {
+  if (event.block.id == "twilightforest:uncrafting_table") {
+    event.cancel()
+  }
+})


### PR DESCRIPTION
Disable players open the Twilight Uncrafting_table, the uncrafting_table will be generated naturally, this is a long-standing problem, even if the usage is turned off in the configuration file, it will crash game when players put items in it.